### PR TITLE
Work-around for non-Debian systems

### DIFF
--- a/code-rack
+++ b/code-rack
@@ -32,4 +32,11 @@ esac
 
 dir="$(dirname "$0")"/${handler//_/-}
 /bin/mkdir -p "$dir"
-/bin/run-parts "$dir"
+if [ -x /bin/run-parts ]
+then
+  /bin/run-parts "$dir"
+else
+  # No run-parts - probably not a Debian system, fallback to emulating run-parts with /usr/bin/find
+  # /usr/bin/find is present on CentOS and FreeBSD
+  /usr/bin/find "$dir" -executable -regex '.*/[A-Za-z0-9_-]+' -exec '{}' \;
+fi


### PR DESCRIPTION
run-parts is part of debianutils and not available on other *nixs.

Find is more common and can emulate run-parts by executing executable files that match the same file naming rules run-parts applies.

Closes #1 