### PR TITLE
Clarified location of hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ You will need to instruct dehydrated to call **code-rack** as its hook:
     $ cat /etc/dehydrated/conf.d/hook.sh
     HOOK=/etc/dehydrated/hooks/code-rack
 
-Then create hooks in subdirectories of `/etc/dehydrated/hooks`. The following
-subdirectories will be used at the appropriate stage of the the **dehyrated**
-process:
+Then create hooks in subdirectories adjacent to **code-rack** (e.g. if `code-rack`
+is in `/etc/dehydrated/hooks` then also create these subdirectories there). The
+following subdirectories will be used at the appropriate stage of the the
+**dehyrated** process:
 
     deploy-challenge
     clean-challenge


### PR DESCRIPTION
`code-rack` uses `dirname $0` to determine where the hook scripts are, not /etc/dehydrated/hooks as the documentation says.

I have changed the wording to make clear that it looks where ever `code-rack` is, instead.  Alternatively, it could be rewritten to make clear that **code-rack** must be installed in /etc/dehydrated/hooks for the instructions to work.