### PR TITLE
code-rack dies with current version of dehydrated

### DIFF
--- a/code-rack
+++ b/code-rack
@@ -28,6 +28,10 @@ case $handler in
         ;;
     exit_hook)
         ;;
+    *)
+        echo "Unknown hook: $handler" >&2
+        exit 0
+        ;;
 esac
 
 dir="$(dirname "$0")"/${handler//_/-}


### PR DESCRIPTION
The script fails, trying to create directory 'this-hookscript-is-broken--dehydrated-is-working-fine--please-ignore-unknown-hooks-in-your-script', when run with dehydrated from Debian stable (10.7 at time of writing).

Added case to ignore unknown hooks.

Closes #9